### PR TITLE
fix: Aplanar estructura de categorías en respuestas del wardrobe

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!uuid/)"
+      "node_modules/(?!(uuid|@toon-format)/)"
     ],
     "collectCoverageFrom": [
       "**/*.(t|j)s"

--- a/src/modules/users/dtos/users.dto.ts
+++ b/src/modules/users/dtos/users.dto.ts
@@ -69,7 +69,10 @@ export class CreateUserDto {
   birthDate: Date;
 
   @ApiProperty({ required: false, title: 'URL de la imagen de perfil' })
-  @IsUrl({}, { message: 'La URL de la imagen de perfil debe ser una URL válida' })
+  @IsUrl(
+    {},
+    { message: 'La URL de la imagen de perfil debe ser una URL válida' },
+  )
   @IsOptional()
   profilePicture: string;
 

--- a/src/modules/wardrobe/controllers/combinations/combinations.controller.spec.ts
+++ b/src/modules/wardrobe/controllers/combinations/combinations.controller.spec.ts
@@ -1,0 +1,423 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CombinationsController } from './combinations.controller';
+import { CombinationsService } from '../../services/combinations.service';
+import { JwtAuthGuard } from '@/modules/security/jwt-strategy/jwt-auth.guard';
+import { RoleGuard } from '@/modules/security/jwt-strategy/roles.guard';
+import { RoleEnum } from '@/modules/security/jwt-strategy/role.enum';
+import {
+  CreateCombinationDto,
+  SaveCombinationDto,
+  AddItemsToCombinationDto,
+} from '../../dtos/combinations.dto';
+import { PaginationDto } from '@/shared/dtos/pagination.dto';
+
+// Mock @toon-format/toon module
+jest.mock('@toon-format/toon', () => ({
+  encode: jest.fn((data) => JSON.stringify(data)),
+}));
+
+describe('CombinationsController', () => {
+  let controller: CombinationsController;
+  let service: CombinationsService;
+
+  const mockCombinationsService = {
+    generateCombinations: jest.fn(),
+    saveCombination: jest.fn(),
+    getCombinations: jest.fn(),
+    updateStatusCombination: jest.fn(),
+    getCombinationById: jest.fn(),
+    addItemsToCombination: jest.fn(),
+    updateStatusItemFromCombination: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CombinationsController],
+      providers: [
+        {
+          provide: CombinationsService,
+          useValue: mockCombinationsService,
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: jest.fn(() => true) })
+      .overrideGuard(RoleGuard)
+      .useValue({ canActivate: jest.fn(() => true) })
+      .compile();
+
+    controller = module.get<CombinationsController>(CombinationsController);
+    service = module.get<CombinationsService>(CombinationsService);
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('generateCombinations', () => {
+    const createDto: CreateCombinationDto = {
+      clothingItemsBase: ['item-1', 'item-2'],
+      categories: ['cat-1', 'cat-2'],
+      occasions: ['Casual', 'Work'],
+      description: 'A casual outfit',
+      take: 5,
+      page: 1,
+    };
+
+    it('should generate combinations successfully', async () => {
+      const expectedResult = {
+        message: 'Combinaciones generadas correctamente',
+        data: {
+          explanation: 'This is a great outfit',
+          items: [
+            {
+              id: 'item-1',
+              name: 'Blue Shirt',
+              primaryColor: '#0000FF',
+              secondaryColor: '#FFFFFF',
+              images: ['http://example.com/image.jpg'],
+            },
+          ],
+        },
+      };
+
+      mockCombinationsService.generateCombinations.mockResolvedValue(
+        expectedResult,
+      );
+
+      const result = await controller.generateCombinations(createDto);
+
+      expect(result).toEqual(expectedResult);
+      expect(service.generateCombinations).toHaveBeenCalledWith(createDto);
+      expect(service.generateCombinations).toHaveBeenCalledTimes(1);
+    });
+
+    it('should pass all parameters to service', async () => {
+      mockCombinationsService.generateCombinations.mockResolvedValue({
+        message: 'Success',
+        data: {},
+      });
+
+      await controller.generateCombinations(createDto);
+
+      expect(service.generateCombinations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clothingItemsBase: createDto.clothingItemsBase,
+          categories: createDto.categories,
+          occasions: createDto.occasions,
+          description: createDto.description,
+        }),
+      );
+    });
+  });
+
+  describe('saveCombination', () => {
+    const saveDto: SaveCombinationDto = {
+      name: 'My Outfit',
+      description: 'A casual outfit',
+      occasions: ['Casual'],
+      isAIGenerated: true,
+      combinationItems: [
+        { wardrobeItemId: 'item-1', explanation: 'Perfect shirt' },
+        { wardrobeItemId: 'item-2', explanation: 'Nice pants' },
+      ],
+    };
+
+    const mockUser = {
+      id: 'user-123',
+      role: RoleEnum.USER,
+    };
+
+    it('should save combination successfully', async () => {
+      const expectedResult = {
+        message: 'Combinación guardada correctamente',
+        data: { id: 'comb-1' },
+      };
+
+      mockCombinationsService.saveCombination.mockResolvedValue(expectedResult);
+
+      const result = await controller.saveCombination(saveDto, mockUser);
+
+      expect(result).toEqual(expectedResult);
+      expect(service.saveCombination).toHaveBeenCalledWith(saveDto, 'user-123');
+    });
+
+    it('should pass user id to service', async () => {
+      mockCombinationsService.saveCombination.mockResolvedValue({
+        message: 'Success',
+        data: {},
+      });
+
+      await controller.saveCombination(saveDto, mockUser);
+
+      expect(service.saveCombination).toHaveBeenCalledWith(
+        saveDto,
+        mockUser.id,
+      );
+    });
+  });
+
+  describe('getCombinations', () => {
+    const mockUser = {
+      id: 'user-123',
+      role: RoleEnum.USER,
+    };
+
+    const pagination: PaginationDto = {
+      page: 1,
+      limit: 20,
+      offset: 0,
+      status: true,
+      search: '',
+    };
+
+    it('should get combinations successfully', async () => {
+      const expectedResult = {
+        message: 'Combinaciones encontradas correctamente',
+        data: [
+          {
+            id: 'comb-1',
+            description: 'Casual outfit',
+            occasions: ['Casual'],
+            isAIGenerated: true,
+          },
+        ],
+      };
+
+      mockCombinationsService.getCombinations.mockResolvedValue(expectedResult);
+
+      const result = await controller.getCombinations(mockUser, pagination);
+
+      expect(result).toEqual(expectedResult);
+      expect(service.getCombinations).toHaveBeenCalledWith(
+        'user-123',
+        pagination,
+      );
+    });
+
+    it('should pass pagination parameters to service', async () => {
+      mockCombinationsService.getCombinations.mockResolvedValue({
+        message: 'Success',
+        data: [],
+      });
+
+      await controller.getCombinations(mockUser, pagination);
+
+      expect(service.getCombinations).toHaveBeenCalledWith(
+        mockUser.id,
+        expect.objectContaining({
+          page: 1,
+          limit: 20,
+          offset: 0,
+          status: true,
+        }),
+      );
+    });
+
+    it('should return empty array when no combinations found', async () => {
+      mockCombinationsService.getCombinations.mockResolvedValue({
+        message: 'No combinations found',
+        data: [],
+      });
+
+      const result = await controller.getCombinations(mockUser, pagination);
+
+      expect(result.data).toEqual([]);
+    });
+  });
+
+  describe('updateCombinationStatus', () => {
+    const combinationId = 'comb-1';
+
+    it('should update combination status successfully', async () => {
+      const expectedResult = {
+        message: 'Combinación actualizada correctamente',
+      };
+
+      mockCombinationsService.updateStatusCombination.mockResolvedValue(
+        expectedResult,
+      );
+
+      const result = await controller.updateCombinationStatus(combinationId);
+
+      expect(result).toEqual(expectedResult);
+      expect(service.updateStatusCombination).toHaveBeenCalledWith(
+        combinationId,
+      );
+    });
+
+    it('should pass combination id to service', async () => {
+      mockCombinationsService.updateStatusCombination.mockResolvedValue({
+        message: 'Success',
+      });
+
+      await controller.updateCombinationStatus(combinationId);
+
+      expect(service.updateStatusCombination).toHaveBeenCalledWith(
+        combinationId,
+      );
+      expect(service.updateStatusCombination).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getCombinationById', () => {
+    const combinationId = 'comb-1';
+
+    it('should get combination by id successfully', async () => {
+      const expectedResult = {
+        message: 'Combinación encontrada correctamente',
+        data: {
+          id: 'comb-1',
+          name: 'My Outfit',
+          description: 'Casual',
+          occasions: ['Casual'],
+          isAIGenerated: true,
+          items: [],
+        },
+      };
+
+      mockCombinationsService.getCombinationById.mockResolvedValue(
+        expectedResult,
+      );
+
+      const result = await controller.getCombinationById(combinationId);
+
+      expect(result).toEqual(expectedResult);
+      expect(service.getCombinationById).toHaveBeenCalledWith(combinationId);
+    });
+
+    it('should return combination with items', async () => {
+      const expectedResult = {
+        message: 'Combinación encontrada correctamente',
+        data: {
+          id: 'comb-1',
+          name: 'My Outfit',
+          description: 'Casual',
+          occasions: ['Casual'],
+          isAIGenerated: true,
+          items: [
+            {
+              id: 'ci-1',
+              wardrobeItem: {
+                id: 'item-1',
+                name: 'Blue Shirt',
+              },
+              aiDescription: 'Perfect shirt',
+            },
+          ],
+        },
+      };
+
+      mockCombinationsService.getCombinationById.mockResolvedValue(
+        expectedResult,
+      );
+
+      const result = await controller.getCombinationById(combinationId);
+
+      expect(result.data.items).toHaveLength(1);
+      expect(result.data.items[0].wardrobeItem.name).toBe('Blue Shirt');
+    });
+  });
+
+  describe('addItemsToCombination', () => {
+    const addItemsDto: AddItemsToCombinationDto = {
+      combinationId: 'comb-1',
+      combinationItems: [
+        { wardrobeItemId: 'item-1', explanation: 'Nice shirt' },
+        { wardrobeItemId: 'item-2', explanation: 'Good pants' },
+      ],
+    };
+
+    it('should add items to combination successfully', async () => {
+      const expectedResult = {
+        message: 'Prendas agregadas correctamente a la combinación',
+      };
+
+      mockCombinationsService.addItemsToCombination.mockResolvedValue(
+        expectedResult,
+      );
+
+      const result = await controller.addItemsToCombination(addItemsDto);
+
+      expect(result).toEqual(expectedResult);
+      expect(service.addItemsToCombination).toHaveBeenCalledWith(addItemsDto);
+    });
+
+    it('should pass all items to service', async () => {
+      mockCombinationsService.addItemsToCombination.mockResolvedValue({
+        message: 'Success',
+      });
+
+      await controller.addItemsToCombination(addItemsDto);
+
+      expect(service.addItemsToCombination).toHaveBeenCalledWith(
+        expect.objectContaining({
+          combinationId: 'comb-1',
+          combinationItems: expect.arrayContaining([
+            expect.objectContaining({ wardrobeItemId: 'item-1' }),
+            expect.objectContaining({ wardrobeItemId: 'item-2' }),
+          ]),
+        }),
+      );
+    });
+
+    it('should handle single item addition', async () => {
+      const singleItemDto = {
+        combinationId: 'comb-1',
+        combinationItems: [
+          { wardrobeItemId: 'item-1', explanation: 'Nice shirt' },
+        ],
+      };
+
+      mockCombinationsService.addItemsToCombination.mockResolvedValue({
+        message: 'Prendas agregadas correctamente a la combinación',
+      });
+
+      await controller.addItemsToCombination(singleItemDto);
+
+      expect(service.addItemsToCombination).toHaveBeenCalledWith(singleItemDto);
+    });
+  });
+
+  describe('deleteItemFromCombination', () => {
+    const combinationId = 'comb-1';
+    const wardrobeItemId = 'item-1';
+
+    it('should update item status in combination successfully', async () => {
+      const expectedResult = {
+        message: 'Prenda eliminada correctamente de la combinación',
+      };
+
+      mockCombinationsService.updateStatusItemFromCombination.mockResolvedValue(
+        expectedResult,
+      );
+
+      const result = await controller.deleteItemFromCombination(
+        combinationId,
+        wardrobeItemId,
+      );
+
+      expect(result).toEqual(expectedResult);
+      expect(service.updateStatusItemFromCombination).toHaveBeenCalledWith(
+        combinationId,
+        wardrobeItemId,
+      );
+    });
+
+    it('should pass both ids to service', async () => {
+      mockCombinationsService.updateStatusItemFromCombination.mockResolvedValue(
+        { message: 'Success' },
+      );
+
+      await controller.deleteItemFromCombination(combinationId, wardrobeItemId);
+
+      expect(service.updateStatusItemFromCombination).toHaveBeenCalledWith(
+        combinationId,
+        wardrobeItemId,
+      );
+      expect(service.updateStatusItemFromCombination).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/modules/wardrobe/prompts/combinations.prompts.ts
+++ b/src/modules/wardrobe/prompts/combinations.prompts.ts
@@ -1,5 +1,5 @@
 import { Category, ClothingItem } from '../interfaces/combinations.interface';
-import { encode } from '@toon-format/toon'
+import { encode } from '@toon-format/toon';
 
 export function generateCombinationsPrompt(
   clothingItemsBase: ClothingItem[],

--- a/src/modules/wardrobe/services/combinations.service.spec.ts
+++ b/src/modules/wardrobe/services/combinations.service.spec.ts
@@ -1,0 +1,593 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CombinationsService } from './combinations.service';
+import { PrismaService } from '@/shared/services/prisma.service';
+import { AiService } from '@/modules/ai/ai.service';
+import { MultimediaService } from '@/modules/multimedia/services/multimedia.service';
+import {
+  Logger,
+  NotFoundException,
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import {
+  CreateCombinationDto,
+  SaveCombinationDto,
+  AddItemsToCombinationDto,
+} from '../dtos/combinations.dto';
+import { PaginationDto } from '@/shared/dtos/pagination.dto';
+
+// Mock @toon-format/toon module
+jest.mock('@toon-format/toon', () => ({
+  encode: jest.fn((data) => JSON.stringify(data)),
+}));
+
+describe('CombinationsService', () => {
+  let service: CombinationsService;
+  let prismaService: PrismaService;
+  let aiService: AiService;
+  let multimediaService: MultimediaService;
+  let logger: Logger;
+
+  const mockPrismaService = {
+    wardrobeItem: {
+      findMany: jest.fn(),
+      findUniqueOrThrow: jest.fn(),
+    },
+    category: {
+      findMany: jest.fn(),
+    },
+    combination: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUniqueOrThrow: jest.fn(),
+      update: jest.fn(),
+    },
+    combinationItem: {
+      createMany: jest.fn(),
+      findFirst: jest.fn(),
+      findFirstOrThrow: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn(),
+    },
+  };
+
+  const mockAiService = {
+    generateJSON: jest.fn(),
+  };
+
+  const mockMultimediaService = {
+    getUrlImage: jest.fn(),
+  };
+
+  const mockLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+    warn: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CombinationsService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+        {
+          provide: AiService,
+          useValue: mockAiService,
+        },
+        {
+          provide: MultimediaService,
+          useValue: mockMultimediaService,
+        },
+        {
+          provide: Logger,
+          useValue: mockLogger,
+        },
+      ],
+    }).compile();
+
+    service = module.get<CombinationsService>(CombinationsService);
+    prismaService = module.get<PrismaService>(PrismaService);
+    aiService = module.get<AiService>(AiService);
+    multimediaService = module.get<MultimediaService>(MultimediaService);
+    logger = module.get<Logger>(Logger);
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('generateCombinations', () => {
+    const createCombinationDto: CreateCombinationDto = {
+      clothingItemsBase: ['item-1', 'item-2'],
+      categories: ['cat-1', 'cat-2'],
+      occasions: ['Casual', 'Work'],
+      description: 'A casual outfit',
+      take: 5,
+      page: 1,
+    };
+
+    const mockBaseItems = [
+      {
+        id: 'item-1',
+        name: 'Blue Shirt',
+        description: 'A blue shirt',
+        season: 'Summer',
+        primaryColor: '#0000FF',
+        secondaryColor: '#FFFFFF',
+        style: 'Casual',
+        material: 'Cotton',
+        size: 'M',
+        categories: [{ id: 'cat-1' }],
+      },
+    ];
+
+    const mockCategories = [
+      {
+        id: 'cat-1',
+        name: 'Shirts',
+        wardrobeItems: [
+          {
+            wardrobeItem: {
+              id: 'item-2',
+              name: 'Black Pants',
+              description: 'Black pants',
+              season: 'All',
+              primaryColor: '#000000',
+              secondaryColor: null,
+              style: 'Formal',
+              material: 'Polyester',
+              size: 'M',
+              categories: [{ id: 'cat-2' }],
+            },
+          },
+        ],
+      },
+    ];
+
+    const mockAiResponse = {
+      outfitRecommendation: [{ id: 'item-1' }, { id: 'item-2' }],
+      overallExplanation: 'This is a great casual outfit',
+    };
+
+    it('should generate combinations successfully', async () => {
+      mockPrismaService.wardrobeItem.findMany.mockResolvedValue(mockBaseItems);
+      mockPrismaService.category.findMany.mockResolvedValue(mockCategories);
+      mockAiService.generateJSON.mockResolvedValue(mockAiResponse);
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        id: 'item-1',
+        name: 'Blue Shirt',
+        primaryColor: '#0000FF',
+        secondaryColor: '#FFFFFF',
+        images: [{ id: 'img-1' }],
+      });
+      mockMultimediaService.getUrlImage.mockResolvedValue(
+        'http://example.com/image.jpg',
+      );
+
+      const result = await service.generateCombinations(createCombinationDto);
+
+      expect(result.message).toBe('Combinaciones generadas correctamente');
+      expect(result.data.explanation).toBe('This is a great casual outfit');
+      expect(result.data.items).toHaveLength(2);
+      expect(mockAiService.generateJSON).toHaveBeenCalled();
+    });
+
+    it('should handle AI service errors', async () => {
+      mockPrismaService.wardrobeItem.findMany.mockResolvedValue(mockBaseItems);
+      mockPrismaService.category.findMany.mockResolvedValue(mockCategories);
+      mockAiService.generateJSON.mockRejectedValue(new Error('AI Error'));
+
+      await expect(
+        service.generateCombinations(createCombinationDto),
+      ).rejects.toThrow();
+    });
+
+    it('should throw InternalServerErrorException if wardrobe item not found during generation', async () => {
+      mockPrismaService.wardrobeItem.findMany.mockResolvedValue(mockBaseItems);
+      mockPrismaService.category.findMany.mockResolvedValue(mockCategories);
+      mockAiService.generateJSON.mockResolvedValue(mockAiResponse);
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockRejectedValue(
+        new Error('Not found'),
+      );
+
+      await expect(
+        service.generateCombinations(createCombinationDto),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('should use default take value if not provided', async () => {
+      const dtoWithoutTake = { ...createCombinationDto, take: undefined };
+      mockPrismaService.wardrobeItem.findMany.mockResolvedValue(mockBaseItems);
+      mockPrismaService.category.findMany.mockResolvedValue([
+        {
+          ...mockCategories[0],
+          wardrobeItems: [],
+        },
+      ]);
+      mockAiService.generateJSON.mockResolvedValue({
+        outfitRecommendation: [],
+        overallExplanation: 'Test',
+      });
+
+      await service.generateCombinations(dtoWithoutTake);
+
+      expect(mockPrismaService.category.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: expect.objectContaining({
+            wardrobeItems: expect.objectContaining({
+              take: 5,
+            }),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('saveCombination', () => {
+    const userId = 'user-123';
+    const saveCombinationDto: SaveCombinationDto = {
+      name: 'My Outfit',
+      description: 'A casual outfit',
+      occasions: ['Casual'],
+      isAIGenerated: true,
+      combinationItems: [
+        { wardrobeItemId: 'item-1', explanation: 'Perfect shirt' },
+        { wardrobeItemId: 'item-2', explanation: 'Nice pants' },
+      ],
+    };
+
+    it('should save combination successfully', async () => {
+      mockPrismaService.combination.create.mockResolvedValue({ id: 'comb-1' });
+      mockPrismaService.combinationItem.createMany.mockResolvedValue({
+        count: 2,
+      });
+
+      const result = await service.saveCombination(saveCombinationDto, userId);
+
+      expect(result.message).toBe('Combinación guardada correctamente');
+      expect(result.data.id).toBe('comb-1');
+      expect(mockPrismaService.combination.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            name: 'My Outfit',
+            userId,
+          }),
+        }),
+      );
+      expect(mockPrismaService.combinationItem.createMany).toHaveBeenCalled();
+    });
+
+    it('should throw InternalServerErrorException on database error', async () => {
+      mockPrismaService.combination.create.mockRejectedValue(
+        new Error('DB Error'),
+      );
+
+      await expect(
+        service.saveCombination(saveCombinationDto, userId),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  describe('getCombinations', () => {
+    const userId = 'user-123';
+    const pagination: PaginationDto = {
+      page: 1,
+      limit: 20,
+      offset: 0,
+      status: true,
+      search: '',
+    };
+
+    it('should return combinations successfully', async () => {
+      const mockCombinations = [
+        {
+          id: 'comb-1',
+          description: 'Casual outfit',
+          occasions: ['Casual'],
+          isAIGenerated: true,
+        },
+      ];
+
+      mockPrismaService.combination.findMany.mockResolvedValue(
+        mockCombinations,
+      );
+
+      const result = await service.getCombinations(userId, pagination);
+
+      expect(result.message).toBe('Combinaciones encontradas correctamente');
+      expect(result.data).toEqual(mockCombinations);
+    });
+
+    it('should throw NotFoundException if no combinations found', async () => {
+      mockPrismaService.combination.findMany.mockResolvedValue([]);
+
+      await expect(service.getCombinations(userId, pagination)).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(service.getCombinations(userId, pagination)).rejects.toThrow(
+        'No se encontraron combinaciones guardadas',
+      );
+    });
+
+    it('should apply pagination parameters', async () => {
+      mockPrismaService.combination.findMany.mockResolvedValue([
+        { id: 'comb-1', description: '', occasions: [], isAIGenerated: false },
+      ]);
+
+      await service.getCombinations(userId, pagination);
+
+      expect(mockPrismaService.combination.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 0,
+          take: 20,
+        }),
+      );
+    });
+  });
+
+  describe('updateStatusCombination', () => {
+    const combinationId = 'comb-1';
+
+    it('should update combination status successfully', async () => {
+      mockPrismaService.combination.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.combination.update.mockResolvedValue({});
+
+      const result = await service.updateStatusCombination(combinationId);
+
+      expect(result.message).toBe('Combinación actualizada correctamente');
+      expect(mockPrismaService.combination.update).toHaveBeenCalledWith({
+        where: { id: combinationId },
+        data: { status: false },
+      });
+    });
+
+    it('should throw NotFoundException if combination not found', async () => {
+      mockPrismaService.combination.findUniqueOrThrow.mockRejectedValue(
+        new Error('Not found'),
+      );
+
+      await expect(
+        service.updateStatusCombination(combinationId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw InternalServerErrorException on update error', async () => {
+      mockPrismaService.combination.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.combination.update.mockRejectedValue(
+        new Error('Update error'),
+      );
+
+      await expect(
+        service.updateStatusCombination(combinationId),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  describe('getCombinationById', () => {
+    const combinationId = 'comb-1';
+
+    it('should return combination by id successfully', async () => {
+      const mockCombination = {
+        id: 'comb-1',
+        name: 'My Outfit',
+        description: 'Casual',
+        occasions: ['Casual'],
+        isAIGenerated: true,
+        items: [
+          {
+            id: 'ci-1',
+            wardrobeItem: {
+              id: 'item-1',
+              name: 'Blue Shirt',
+              description: 'A shirt',
+              season: 'Summer',
+              primaryColor: '#0000FF',
+              secondaryColor: null,
+              style: 'Casual',
+              material: 'Cotton',
+              size: 'M',
+              categories: [{ category: { id: 'cat-1', name: 'Shirts' } }],
+            },
+            aiDescription: 'Perfect shirt',
+          },
+        ],
+      };
+
+      mockPrismaService.combination.findUniqueOrThrow.mockResolvedValue(
+        mockCombination,
+      );
+
+      const result = await service.getCombinationById(combinationId);
+
+      expect(result.message).toBe('Combinación encontrada correctamente');
+      expect(result.data).toEqual(mockCombination);
+    });
+
+    it('should throw NotFoundException if combination not found', async () => {
+      mockPrismaService.combination.findUniqueOrThrow.mockRejectedValue(
+        new Error('Not found'),
+      );
+
+      await expect(service.getCombinationById(combinationId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('addItemsToCombination', () => {
+    const addItemsDto: AddItemsToCombinationDto = {
+      combinationId: 'comb-1',
+      combinationItems: [
+        { wardrobeItemId: 'item-1', explanation: 'Nice shirt' },
+        { wardrobeItemId: 'item-2', explanation: 'Good pants' },
+      ],
+    };
+
+    it('should add new items to combination successfully', async () => {
+      mockPrismaService.combination.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.combinationItem.findFirst.mockResolvedValue(null);
+      mockPrismaService.combinationItem.create.mockResolvedValue({});
+
+      const result = await service.addItemsToCombination(addItemsDto);
+
+      expect(result.message).toBe(
+        'Prendas agregadas correctamente a la combinación',
+      );
+      expect(mockPrismaService.combinationItem.create).toHaveBeenCalledTimes(2);
+    });
+
+    it('should reactivate existing inactive items', async () => {
+      mockPrismaService.combination.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.combinationItem.findFirst.mockResolvedValue({
+        id: 'ci-1',
+        status: false,
+        wardrobeItem: { name: 'Blue Shirt' },
+      });
+      mockPrismaService.combinationItem.update.mockResolvedValue({});
+
+      const result = await service.addItemsToCombination(addItemsDto);
+
+      expect(result.message).toBe(
+        'Prendas agregadas correctamente a la combinación',
+      );
+      expect(mockPrismaService.combinationItem.update).toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException if item is already active in combination', async () => {
+      mockPrismaService.combination.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.combinationItem.findFirst.mockResolvedValue({
+        id: 'ci-1',
+        status: true,
+        wardrobeItem: { name: 'Blue Shirt' },
+      });
+
+      await expect(service.addItemsToCombination(addItemsDto)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.addItemsToCombination(addItemsDto)).rejects.toThrow(
+        "La prenda 'Blue Shirt' ya está en la combinación",
+      );
+    });
+
+    it('should throw NotFoundException if combination not found', async () => {
+      mockPrismaService.combination.findUniqueOrThrow.mockRejectedValue(
+        new Error('Not found'),
+      );
+
+      await expect(service.addItemsToCombination(addItemsDto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw InternalServerErrorException if combination is inactive', async () => {
+      mockPrismaService.combination.findUniqueOrThrow.mockResolvedValue({
+        status: false,
+      });
+
+      await expect(service.addItemsToCombination(addItemsDto)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+      await expect(service.addItemsToCombination(addItemsDto)).rejects.toThrow(
+        'No se puede agregar prendas a una combinación eliminada',
+      );
+    });
+
+    it('should throw InternalServerErrorException on create error', async () => {
+      mockPrismaService.combination.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.combinationItem.findFirst.mockResolvedValue(null);
+      mockPrismaService.combinationItem.create.mockRejectedValue(
+        new Error('Create error'),
+      );
+
+      await expect(service.addItemsToCombination(addItemsDto)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe('updateStatusItemFromCombination', () => {
+    const combinationId = 'comb-1';
+    const wardrobeItemId = 'item-1';
+
+    it('should update item status in combination successfully', async () => {
+      mockPrismaService.combinationItem.findFirstOrThrow.mockResolvedValue({
+        status: true,
+        combination: { status: true },
+      });
+      mockPrismaService.combinationItem.updateMany.mockResolvedValue({});
+
+      const result = await service.updateStatusItemFromCombination(
+        combinationId,
+        wardrobeItemId,
+      );
+
+      expect(result.message).toBe(
+        'Prenda eliminada correctamente de la combinación',
+      );
+      expect(mockPrismaService.combinationItem.updateMany).toHaveBeenCalledWith(
+        {
+          where: { wardrobeItemId, combinationId },
+          data: { status: false },
+        },
+      );
+    });
+
+    it('should throw NotFoundException if item not found in combination', async () => {
+      mockPrismaService.combinationItem.findFirstOrThrow.mockRejectedValue(
+        new Error('Not found'),
+      );
+
+      await expect(
+        service.updateStatusItemFromCombination(combinationId, wardrobeItemId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw InternalServerErrorException if combination is inactive', async () => {
+      mockPrismaService.combinationItem.findFirstOrThrow.mockResolvedValue({
+        status: true,
+        combination: { status: false },
+      });
+
+      await expect(
+        service.updateStatusItemFromCombination(combinationId, wardrobeItemId),
+      ).rejects.toThrow(InternalServerErrorException);
+      await expect(
+        service.updateStatusItemFromCombination(combinationId, wardrobeItemId),
+      ).rejects.toThrow(
+        'No se puede eliminar prendas de una combinación eliminada',
+      );
+    });
+
+    it('should throw InternalServerErrorException on update error', async () => {
+      mockPrismaService.combinationItem.findFirstOrThrow.mockResolvedValue({
+        status: true,
+        combination: { status: true },
+      });
+      mockPrismaService.combinationItem.updateMany.mockRejectedValue(
+        new Error('Update error'),
+      );
+
+      await expect(
+        service.updateStatusItemFromCombination(combinationId, wardrobeItemId),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+});

--- a/src/modules/wardrobe/services/combinations.service.ts
+++ b/src/modules/wardrobe/services/combinations.service.ts
@@ -88,8 +88,8 @@ export class CombinationsService {
             status: true,
             wardrobeItem: {
               status: true,
-            }
-          }
+            },
+          },
         },
       },
     });

--- a/src/modules/wardrobe/services/wardrobe.service.spec.ts
+++ b/src/modules/wardrobe/services/wardrobe.service.spec.ts
@@ -1,0 +1,627 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WardrobeService } from './wardrobe.service';
+import { PrismaService } from '@/shared/services/prisma.service';
+import { MultimediaService } from '@/modules/multimedia/services/multimedia.service';
+import {
+  Logger,
+  BadRequestException,
+  NotFoundException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { getQueueToken } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { CreateClothesDto, UpdateClothesDto } from '../dtos/wardrobe.dtos';
+import { PaginationDto } from '@/shared/dtos/pagination.dto';
+
+describe('WardrobeService', () => {
+  let service: WardrobeService;
+  let prismaService: PrismaService;
+  let multimediaService: MultimediaService;
+  let imageQueue: Queue;
+  let logger: Logger;
+
+  const mockPrismaService = {
+    wardrobeItem: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      findUniqueOrThrow: jest.fn(),
+      update: jest.fn(),
+      count: jest.fn(),
+    },
+    wardrobeCategory: {
+      createMany: jest.fn(),
+      findFirst: jest.fn(),
+      findFirstOrThrow: jest.fn(),
+      findMany: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    image: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+    $transaction: jest.fn((callback) => callback(mockPrismaService)),
+  };
+
+  const mockMultimediaService = {
+    getUrlImage: jest.fn(),
+  };
+
+  const mockImageQueue = {
+    add: jest.fn(),
+  };
+
+  const mockLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+    warn: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WardrobeService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+        {
+          provide: MultimediaService,
+          useValue: mockMultimediaService,
+        },
+        {
+          provide: getQueueToken('images'),
+          useValue: mockImageQueue,
+        },
+        {
+          provide: Logger,
+          useValue: mockLogger,
+        },
+      ],
+    }).compile();
+
+    service = module.get<WardrobeService>(WardrobeService);
+    prismaService = module.get<PrismaService>(PrismaService);
+    multimediaService = module.get<MultimediaService>(MultimediaService);
+    imageQueue = module.get<Queue>(getQueueToken('images'));
+    logger = module.get<Logger>(Logger);
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    const userId = 'user-123';
+    const createDto: CreateClothesDto = {
+      name: 'Test Shirt',
+      description: 'A test shirt',
+      season: 'Summer',
+      primaryColor: '#FF0000',
+      secondaryColor: '#00FF00',
+      style: 'Casual',
+      material: 'Cotton',
+      size: 'M',
+      categoriesId: ['cat-1', 'cat-2'],
+    };
+
+    it('should create a wardrobe item successfully', async () => {
+      mockPrismaService.wardrobeCategory.findFirst.mockResolvedValue(null);
+      mockPrismaService.wardrobeItem.create.mockResolvedValue({ id: 'item-1' });
+      mockPrismaService.wardrobeCategory.createMany.mockResolvedValue({
+        count: 2,
+      });
+
+      const result = await service.create(createDto, userId);
+
+      expect(result).toEqual({
+        message: 'Prenda agregada correctamente',
+        data: { id: 'item-1' },
+      });
+      expect(mockPrismaService.wardrobeItem.create).toHaveBeenCalled();
+      expect(mockPrismaService.wardrobeCategory.createMany).toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException if item already exists in category', async () => {
+      mockPrismaService.wardrobeCategory.findFirst.mockResolvedValue({
+        category: { name: 'Shirts' },
+      });
+
+      await expect(service.create(createDto, userId)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.create(createDto, userId)).rejects.toThrow(
+        'Ya existe la prenda en la categoría Shirts',
+      );
+    });
+
+    it('should create item without categories if categoriesId is empty', async () => {
+      const dtoWithoutCategories = { ...createDto, categoriesId: [] };
+      mockPrismaService.wardrobeCategory.findFirst.mockResolvedValue(null);
+      mockPrismaService.wardrobeItem.create.mockResolvedValue({ id: 'item-1' });
+
+      const result = await service.create(dtoWithoutCategories, userId);
+
+      expect(result).toEqual({
+        message: 'Prenda agregada correctamente',
+        data: { id: 'item-1' },
+      });
+      expect(mockPrismaService.wardrobeItem.create).toHaveBeenCalled();
+      expect(
+        mockPrismaService.wardrobeCategory.createMany,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException on database error', async () => {
+      mockPrismaService.wardrobeCategory.findFirst.mockResolvedValue(null);
+      mockPrismaService.wardrobeItem.create.mockRejectedValue(
+        new Error('DB Error'),
+      );
+
+      await expect(service.create(createDto, userId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('getClothes', () => {
+    const userId = 'user-123';
+    const pagination: PaginationDto = {
+      page: 1,
+      limit: 20,
+      offset: 0,
+      status: true,
+      search: '',
+    };
+
+    it('should return paginated wardrobe items', async () => {
+      const mockItems = [
+        {
+          id: 'item-1',
+          name: 'Test Shirt',
+          season: 'Summer',
+          primaryColor: '#FF0000',
+          secondaryColor: '#00FF00',
+          style: 'Casual',
+          size: 'M',
+          images: [{ id: 'img-1' }],
+          categories: [{ category: { id: 'cat-1', name: 'Shirts' } }],
+        },
+      ];
+
+      mockPrismaService.wardrobeItem.findMany.mockResolvedValue(mockItems);
+      mockPrismaService.wardrobeItem.count.mockResolvedValue(1);
+      mockMultimediaService.getUrlImage.mockResolvedValue(
+        'http://example.com/image.jpg',
+      );
+
+      const result = await service.getClothes(userId, pagination);
+
+      expect(result).toEqual({
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'item-1',
+            name: 'Test Shirt',
+          }),
+        ]),
+        page: 1,
+        limit: 20,
+        total: 1,
+        totalPages: 1,
+        hasMore: false,
+        nextPage: null,
+      });
+    });
+
+    it('should filter by categoryId when provided', async () => {
+      const categoryId = 'cat-1';
+      mockPrismaService.wardrobeItem.findMany.mockResolvedValue([]);
+      mockPrismaService.wardrobeItem.count.mockResolvedValue(0);
+
+      await service.getClothes(userId, pagination, categoryId);
+
+      expect(mockPrismaService.wardrobeItem.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            categories: {
+              some: {
+                categoryId: 'cat-1',
+              },
+            },
+          }),
+        }),
+      );
+    });
+
+    it('should handle search parameter', async () => {
+      const paginationWithSearch = { ...pagination, search: 'shirt' };
+      mockPrismaService.wardrobeItem.findMany.mockResolvedValue([]);
+      mockPrismaService.wardrobeItem.count.mockResolvedValue(0);
+
+      await service.getClothes(userId, paginationWithSearch);
+
+      expect(mockPrismaService.wardrobeItem.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            name: {
+              contains: 'shirt',
+              mode: 'insensitive',
+            },
+          }),
+        }),
+      );
+    });
+
+    it('should calculate hasMore and nextPage correctly', async () => {
+      mockPrismaService.wardrobeItem.findMany.mockResolvedValue([
+        { id: 'item-1', images: [], categories: [] },
+      ]);
+      mockPrismaService.wardrobeItem.count.mockResolvedValue(50);
+
+      const result = await service.getClothes(userId, pagination);
+
+      expect(result.hasMore).toBe(true);
+      expect(result.nextPage).toBe(2);
+      expect(result.totalPages).toBe(3);
+    });
+  });
+
+  describe('getClothesById', () => {
+    const itemId = 'item-1';
+
+    it('should return a wardrobe item by id', async () => {
+      const mockItem = {
+        name: 'Test Shirt',
+        description: 'A test shirt',
+        season: 'Summer',
+        primaryColor: '#FF0000',
+        secondaryColor: '#00FF00',
+        style: 'Casual',
+        material: 'Cotton',
+        size: 'M',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        categories: [{ category: { id: 'cat-1', name: 'Shirts' } }],
+        images: [{ id: 'img-1' }],
+        combinations: [{ id: 'comb-1' }],
+      };
+
+      mockPrismaService.wardrobeItem.findUniqueOrThrow
+        .mockResolvedValueOnce({ status: true })
+        .mockResolvedValueOnce(mockItem);
+      mockMultimediaService.getUrlImage.mockResolvedValue(
+        'http://example.com/image.jpg',
+      );
+
+      const result = await service.getClothesById(itemId);
+
+      expect(result.message).toBe('Prenda encontrada');
+      expect(result.data).toBeDefined();
+    });
+
+    it('should throw NotFoundException if item does not exist', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockRejectedValue(
+        new Error('Not found'),
+      );
+
+      await expect(service.getClothesById(itemId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw BadRequestException if item is deactivated', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        status: false,
+      });
+
+      await expect(service.getClothesById(itemId)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.getClothesById(itemId)).rejects.toThrow(
+        'La prenda se encuentra desactivada',
+      );
+    });
+  });
+
+  describe('update', () => {
+    const itemId = 'item-1';
+    const updateDto: UpdateClothesDto = {
+      name: 'Updated Shirt',
+      description: 'Updated description',
+      season: 'Winter',
+      primaryColor: '#0000FF',
+      style: 'Formal',
+      material: 'Wool',
+      size: 'L',
+    };
+
+    it('should update a wardrobe item successfully', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+        userId: 'user-123',
+      });
+      mockPrismaService.wardrobeCategory.findMany.mockResolvedValue([
+        { category: { id: 'cat-1' } },
+      ]);
+      mockPrismaService.wardrobeCategory.findFirst.mockResolvedValue(null);
+      mockPrismaService.wardrobeItem.update.mockResolvedValue({});
+
+      const result = await service.update(updateDto, itemId);
+
+      expect(result.message).toBe('Prenda actualizada con éxito');
+      expect(mockPrismaService.wardrobeItem.update).toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException if item does not exist', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockRejectedValue(
+        new Error('Not found'),
+      );
+
+      await expect(service.update(updateDto, itemId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw BadRequestException if item is deactivated', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        status: false,
+        userId: 'user-123',
+      });
+
+      await expect(service.update(updateDto, itemId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should verify name uniqueness in categories when name is updated', async () => {
+      const dtoWithNewName = { name: 'New Name' };
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+        userId: 'user-123',
+      });
+      mockPrismaService.wardrobeCategory.findMany.mockResolvedValue([
+        { category: { id: 'cat-1' } },
+      ]);
+      mockPrismaService.wardrobeCategory.findFirst.mockResolvedValue({
+        category: { name: 'Shirts' },
+      });
+
+      await expect(service.update(dtoWithNewName, itemId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('updateStatus', () => {
+    const itemId = 'item-1';
+
+    it('should toggle item status successfully', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.wardrobeItem.update.mockResolvedValue({});
+
+      const result = await service.updateStatus(itemId);
+
+      expect(result.message).toBe('Estado de la prenda actualizada con éxito');
+      expect(mockPrismaService.wardrobeItem.update).toHaveBeenCalledWith({
+        where: { id: itemId },
+        data: { status: false },
+      });
+    });
+
+    it('should throw NotFoundException if item does not exist', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockRejectedValue(
+        new Error('Not found'),
+      );
+
+      await expect(service.updateStatus(itemId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('addCategory', () => {
+    const itemId = 'item-1';
+    const categoryId = 'cat-1';
+
+    it('should add category to item successfully', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.wardrobeCategory.findFirst.mockResolvedValue(null);
+      mockPrismaService.wardrobeCategory.create.mockResolvedValue({});
+
+      const result = await service.addCategory(itemId, categoryId);
+
+      expect(result.message).toBe('Prenda asociada a la categoría con éxito');
+      expect(mockPrismaService.wardrobeCategory.create).toHaveBeenCalled();
+    });
+
+    it('should reactivate category if it exists but is inactive', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.wardrobeCategory.findFirst.mockResolvedValue({
+        status: false,
+      });
+      mockPrismaService.wardrobeCategory.findFirstOrThrow.mockResolvedValue({
+        id: 'wc-1',
+      });
+      mockPrismaService.wardrobeCategory.update.mockResolvedValue({});
+
+      const result = await service.addCategory(itemId, categoryId);
+
+      expect(result.message).toBe('Categoría actualizada con éxito');
+    });
+
+    it('should throw BadRequestException if category is already active', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.wardrobeCategory.findFirst.mockResolvedValue({
+        status: true,
+      });
+
+      await expect(service.addCategory(itemId, categoryId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('deactivateCategory', () => {
+    const itemId = 'item-1';
+    const categoryId = 'cat-1';
+
+    it('should deactivate category successfully', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.wardrobeCategory.findFirst.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.wardrobeCategory.findFirstOrThrow.mockResolvedValue({
+        id: 'wc-1',
+      });
+      mockPrismaService.wardrobeCategory.update.mockResolvedValue({});
+
+      const result = await service.deactivateCategory(itemId, categoryId);
+
+      expect(result.message).toBe('Categoría actualizada con éxito');
+    });
+
+    it('should throw BadRequestException if category is already inactive', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.wardrobeCategory.findFirst.mockResolvedValue({
+        status: false,
+      });
+
+      await expect(
+        service.deactivateCategory(itemId, categoryId),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('uploadFiles', () => {
+    const itemId = 'item-1';
+    const mockFiles = [
+      { filename: 'test1.jpg', buffer: Buffer.from('test1') },
+      { filename: 'test2.jpg', buffer: Buffer.from('test2') },
+    ] as Storage.MultipartFile[];
+
+    it('should upload files successfully', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        images: [],
+      });
+      mockImageQueue.add.mockResolvedValue({});
+
+      const result = await service.uploadFiles(mockFiles, itemId);
+
+      expect(result.message).toBe('Archivo subido');
+      expect(mockImageQueue.add).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw BadRequestException if max images reached', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        images: [{}, {}, {}, {}],
+      });
+
+      await expect(service.uploadFiles(mockFiles, itemId)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.uploadFiles(mockFiles, itemId)).rejects.toThrow(
+        'Sólo es permitido tener 4 imágenes por prenda',
+      );
+    });
+
+    it('should throw NotFoundException if item does not exist', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockRejectedValue(
+        new Error('Not found'),
+      );
+
+      await expect(service.uploadFiles(mockFiles, itemId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('deactivateImage', () => {
+    const itemId = 'item-1';
+    const imageId = 'img-1';
+
+    it('should deactivate image successfully', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.image.findFirst.mockResolvedValue({ status: true });
+      mockPrismaService.image.update.mockResolvedValue({});
+
+      const result = await service.deactivateImage(itemId, imageId);
+
+      expect(result.message).toBe('Imagen desactivada con éxito');
+      expect(mockPrismaService.image.update).toHaveBeenCalledWith({
+        where: { id: imageId },
+        data: { status: false },
+      });
+    });
+
+    it('should throw NotFoundException if image does not exist', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.image.findFirst.mockResolvedValue(null);
+
+      await expect(service.deactivateImage(itemId, imageId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw BadRequestException if image is already inactive', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.image.findFirst.mockResolvedValue({ status: false });
+
+      await expect(service.deactivateImage(itemId, imageId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('activateImage', () => {
+    const itemId = 'item-1';
+    const imageId = 'img-1';
+
+    it('should activate image successfully', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.image.findFirst.mockResolvedValue({ status: false });
+      mockPrismaService.image.update.mockResolvedValue({});
+
+      const result = await service.activateImage(itemId, imageId);
+
+      expect(result.message).toBe('Imagen activada con éxito');
+      expect(mockPrismaService.image.update).toHaveBeenCalledWith({
+        where: { id: imageId },
+        data: { status: true },
+      });
+    });
+
+    it('should throw BadRequestException if image is already active', async () => {
+      mockPrismaService.wardrobeItem.findUniqueOrThrow.mockResolvedValue({
+        status: true,
+      });
+      mockPrismaService.image.findFirst.mockResolvedValue({ status: true });
+
+      await expect(service.activateImage(itemId, imageId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+});

--- a/src/modules/wardrobe/services/wardrobe.service.ts
+++ b/src/modules/wardrobe/services/wardrobe.service.ts
@@ -107,25 +107,25 @@ export class WardrobeService {
           throw new BadRequestException('No se pudo crear la prenda');
         });
 
-      if (data.categoriesId?.length <= 0) return;
-
-      const wardrobeCategories = data.categoriesId.map((category) => {
-        return {
-          wardrobeItemId: itemCreated.id,
-          categoryId: category,
-        };
-      });
-
-      await cnx.wardrobeCategory
-        .createMany({
-          data: wardrobeCategories,
-        })
-        .catch((e) => {
-          this.logger.error(e.message, WardrobeService.name);
-          throw new InternalServerErrorException(
-            'No se pudo enlazar las categorías con las prenda',
-          );
+      if (data.categoriesId?.length > 0) {
+        const wardrobeCategories = data.categoriesId.map((category) => {
+          return {
+            wardrobeItemId: itemCreated.id,
+            categoryId: category,
+          };
         });
+
+        await cnx.wardrobeCategory
+          .createMany({
+            data: wardrobeCategories,
+          })
+          .catch((e) => {
+            this.logger.error(e.message, WardrobeService.name);
+            throw new InternalServerErrorException(
+              'No se pudo enlazar las categorías con las prenda',
+            );
+          });
+      }
 
       return itemCreated;
     });


### PR DESCRIPTION
## Descripción

Este PR resuelve el issue #39 - "El array de categories no contiene id y no está bien construido"

### Problema

Cuando se recibían los datos del wardrobe, el array de `categories` tenía una estructura anidada innecesaria:

```json
{
  "categories": [
    { "category": { "name": "Tops" } },
    { "category": { "name": "Casual" } }
  ]
}
```

Esto requería hacer "drilling" de `categories.category` en el frontend para acceder a los datos.

### Solución

Se implementó la transformación de datos para aplanar la estructura, devolviendo ahora:

```json
{
  "categories": [
    { "id": "uuid-1", "name": "Tops" },
    { "id": "uuid-2", "name": "Casual" }
  ]
}
```

### Cambios realizados

- **`wardrobe.service.ts`**:
  - `getClothes()`: Agregado `id` al select de categorías y transformación para aplanar la estructura
  - `getClothesById()`: Agregada transformación para aplanar la estructura de categorías

### Beneficios

- ✅ Proporciona el `id` de cada categoría para operaciones del frontend
- ✅ Elimina el anidamiento innecesario de `categories.category`
- ✅ Mantiene consistencia entre los diferentes endpoints
- ✅ Simplifica el consumo de la API desde el frontend

Closes #39