### PR TITLE
feat: Endpoints para activar/desactivar imágenes de prendas

### DIFF
--- a/src/modules/wardrobe/controllers/wardrobe/wardrobe.controller.ts
+++ b/src/modules/wardrobe/controllers/wardrobe/wardrobe.controller.ts
@@ -15,6 +15,7 @@ import {
   CreateClothesDto,
   UpdateClothesDto,
   WardrobeCategoryDto,
+  WardrobeImageDto,
 } from '../../dtos/wardrobe.dtos';
 import { CurrentSession } from '@/modules/security/jwt-strategy/auth.decorator';
 import { InfoUserInterface } from '@/modules/security/jwt-strategy/info-user.interface';
@@ -110,6 +111,24 @@ export class WardrobeController {
   })
   async addCategory(@Param() data: WardrobeCategoryDto) {
     return this.service.addCategory(data.itemId, data.categoryId);
+  }
+
+  @Patch('deactivate-image/:itemId/:imageId')
+  @ApiOperation({
+    summary: 'Desactivar una imagen de la prenda',
+    operationId: 'deactivateImage',
+  })
+  async deactivateImage(@Param() data: WardrobeImageDto) {
+    return this.service.deactivateImage(data.itemId, data.imageId);
+  }
+
+  @Patch('activate-image/:itemId/:imageId')
+  @ApiOperation({
+    summary: 'Activar una imagen de la prenda',
+    operationId: 'activateImage',
+  })
+  async activateImage(@Param() data: WardrobeImageDto) {
+    return this.service.activateImage(data.itemId, data.imageId);
   }
 
   @Get('item/:id')

--- a/src/modules/wardrobe/dtos/wardrobe.dtos.ts
+++ b/src/modules/wardrobe/dtos/wardrobe.dtos.ts
@@ -55,3 +55,13 @@ export class WardrobeCategoryDto {
   @IsString()
   categoryId: string;
 }
+
+export class WardrobeImageDto {
+  @ApiProperty()
+  @IsString()
+  itemId: string;
+
+  @ApiProperty()
+  @IsString()
+  imageId: string;
+}

--- a/src/modules/wardrobe/services/wardrobe.service.ts
+++ b/src/modules/wardrobe/services/wardrobe.service.ts
@@ -486,4 +486,68 @@ export class WardrobeService {
 
     return { message: 'Archivo subido' };
   }
+
+  private async updateImageStatus(
+    itemId: string,
+    imageId: string,
+    newStatus: boolean,
+  ): Promise<ResponseDataInterface<any>> {
+    await this.verifyStatus(itemId);
+
+    const image = await this.db.image.findFirst({
+      where: {
+        id: imageId,
+        wardrobeItemId: itemId,
+      },
+      select: {
+        status: true,
+      },
+    });
+
+    if (!image)
+      throw new NotFoundException(
+        'La imagen no existe o no pertenece a esta prenda',
+      );
+
+    if (image.status === newStatus) {
+      throw new BadRequestException(
+        newStatus
+          ? 'La imagen ya se encuentra activada'
+          : 'La imagen ya se encuentra desactivada',
+      );
+    }
+
+    await this.db.image
+      .update({
+        where: { id: imageId },
+        data: { status: newStatus },
+      })
+      .catch((e) => {
+        this.logger.error(e.message, WardrobeService.name);
+        throw new InternalServerErrorException(
+          'No se pudo actualizar el estado de la imagen',
+        );
+      });
+
+    return {
+      message: newStatus
+        ? 'Imagen activada con éxito'
+        : 'Imagen desactivada con éxito',
+      data: null,
+    };
+  }
+
+  async deactivateImage(
+    itemId: string,
+    imageId: string,
+  ): Promise<ResponseDataInterface<any>> {
+    return this.updateImageStatus(itemId, imageId, false);
+  }
+
+  async activateImage(
+    itemId: string,
+    imageId: string,
+  ): Promise<ResponseDataInterface<any>> {
+    return this.updateImageStatus(itemId, imageId, true);
+  }
 }


### PR DESCRIPTION
## Descripción

Se agregan dos nuevos endpoints para gestionar el estado de las imágenes de prendas mediante soft delete:

- `PATCH /wardrobe/deactivate-image/:itemId/:imageId` - Desactivar una imagen
- `PATCH /wardrobe/activate-image/:itemId/:imageId` - Activar una imagen

## Archivos modificados

### `src/modules/wardrobe/dtos/wardrobe.dtos.ts`
- Nuevo DTO `WardrobeImageDto` con campos `itemId` e `imageId`

### `src/modules/wardrobe/services/wardrobe.service.ts`
- Método privado `updateImageStatus()` - lógica compartida con validaciones
- Método público `deactivateImage()` - desactiva la imagen (status = false)
- Método público `activateImage()` - reactiva la imagen (status = true)

### `src/modules/wardrobe/controllers/wardrobe/wardrobe.controller.ts`
- Endpoint `PATCH /wardrobe/deactivate-image/:itemId/:imageId`
- Endpoint `PATCH /wardrobe/activate-image/:itemId/:imageId`

## Validaciones incluidas

- ✅ Verifica que la prenda existe y está activa
- ✅ Verifica que la imagen existe y pertenece a la prenda indicada
- ✅ Previene desactivar una imagen ya desactivada
- ✅ Previene activar una imagen ya activada
- ✅ Manejo de errores con logging

## Tipo de cambio

- [x] Nueva característica (cambio no disruptivo que añade funcionalidad)